### PR TITLE
Use ASInterfaceStateDelegate

### DIFF
--- a/TextureBridging.podspec
+++ b/TextureBridging.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.name         = "TextureBridging"
-    s.version      = "1.1.0"
+    s.version      = "1.2.0"
     s.summary      = "Allows bringing ASDisplayNode into the world of AutoLayout."
   
     s.description  = <<-DESC

--- a/TextureBridgingDemo/BridgeToAutoLayoutViewController.swift
+++ b/TextureBridgingDemo/BridgeToAutoLayoutViewController.swift
@@ -66,7 +66,7 @@ extension BridgeToAutoLayoutViewController {
     override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
       
       return ASInsetLayoutSpec(
-        insets: .init(top: 8, left: 8, bottom: 8, right: 8),
+        insets: .zero,
         child: textNode
       )
     }


### PR DESCRIPTION
Up : performance (memory usage), stability.

Use ASInterfaceStateDelegate to get notified of `layout did finish`.
Due to this, we've done to reduce the number of layers.
And before, in a specific case, `calculateLayoutDidChange` is not called.
this issue has been also fixed.

But, it seems that ASInterfaceStateDelegate also has the same issue.