### PR TITLE
Support userInterfaceStyle switching in NodeView

### DIFF
--- a/Development/TextureBridging.xcodeproj/project.pbxproj
+++ b/Development/TextureBridging.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		4B305D6D2AAB8B120067A836 /* TextureBridging in Frameworks */ = {isa = PBXBuildFile; productRef = 4B305D6C2AAB8B120067A836 /* TextureBridging */; };
 		4B305D712AAB8BC40067A836 /* TextureSwiftSupport in Frameworks */ = {isa = PBXBuildFile; productRef = 4B305D702AAB8BC40067A836 /* TextureSwiftSupport */; };
 		4B305D742AAB8BD70067A836 /* MondrianLayout in Frameworks */ = {isa = PBXBuildFile; productRef = 4B305D732AAB8BD70067A836 /* MondrianLayout */; };
-		4B305D762AAB8BD70067A836 /* MondrianLayoutDynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 4B305D752AAB8BD70067A836 /* MondrianLayoutDynamic */; };
 		4B305D792AAB8BE90067A836 /* TypedTextAttributes in Frameworks */ = {isa = PBXBuildFile; productRef = 4B305D782AAB8BE90067A836 /* TypedTextAttributes */; };
 		4B305D7C2AAB8BFB0067A836 /* StackScrollView in Frameworks */ = {isa = PBXBuildFile; productRef = 4B305D7B2AAB8BFB0067A836 /* StackScrollView */; };
 		4B5E351B228BF3A000E6B966 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5E351A228BF3A000E6B966 /* AppDelegate.swift */; };
@@ -55,7 +54,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4B305D762AAB8BD70067A836 /* MondrianLayoutDynamic in Frameworks */,
 				4B305D742AAB8BD70067A836 /* MondrianLayout in Frameworks */,
 				4B305D792AAB8BE90067A836 /* TypedTextAttributes in Frameworks */,
 				4B305D712AAB8BC40067A836 /* TextureSwiftSupport in Frameworks */,

--- a/Development/TextureBridgingDemo/DemoStackScrollViewController.swift
+++ b/Development/TextureBridgingDemo/DemoStackScrollViewController.swift
@@ -43,11 +43,27 @@ extension DemoStackScrollViewController {
 
       automaticallyManagesSubnodes = true
 
-      backgroundColor = .orange
+      backgroundColor = .orange.withAlphaComponent(0.5)
 
-      textNode.attributedText = NSAttributedString(string: """
-Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
-""")
+      textNode.attributedText = NSAttributedString(
+        string: """
+        Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+        """,
+        attributes: [
+          .foregroundColor: UIColor.init {
+            switch $0.userInterfaceStyle {
+            case .light:
+              return .black
+            case .dark:
+              return .white
+            case .unspecified:
+              return .black
+            @unknown default:
+              return .black
+            }
+          }
+        ]
+      )
     }
 
     override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
@@ -66,7 +82,23 @@ Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
 
       let nodes = (0..<30).map { i -> ASTextNode in
         let text = ASTextNode()
-        text.attributedText = NSAttributedString(string: "Hello")
+        text.attributedText = NSAttributedString(
+          string: "Hello",
+          attributes: [
+            .foregroundColor: UIColor.init {
+              switch $0.userInterfaceStyle {
+              case .light:
+                return .systemBlue
+              case .dark:
+                return .systemGreen
+              case .unspecified:
+                return .systemBlue
+              @unknown default:
+                return .systemBlue
+              }
+            }
+          ]
+        )
         return text
       }
 
@@ -74,7 +106,7 @@ Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
 
       super.init()
 
-      backgroundColor = .red
+      backgroundColor = .red.withAlphaComponent(0.5)
 
       automaticallyManagesSubnodes = true
 

--- a/Sources/TextureBridging/NodeView.swift
+++ b/Sources/TextureBridging/NodeView.swift
@@ -211,6 +211,10 @@ private final class _InternalNodeView<D: ASDisplayNode>: UILabel /* To use `text
       self?.invalidateIntrinsicContentSize()
     }
 
+    ASTraitCollectionPropagateDown(
+      wrapper,
+      ASPrimitiveTraitCollectionFromUITraitCollection(traitCollection)
+    )
   }
 
   @available(*, unavailable)
@@ -252,8 +256,26 @@ private final class _InternalNodeView<D: ASDisplayNode>: UILabel /* To use `text
   override func layoutSubviews() {
 
     super.layoutSubviews()
-
     wrapper.frame = bounds
+    propagateTraitCollectionIfNeeded()
+  }
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    propagateTraitCollectionIfNeeded()
+  }
+
+  private func propagateTraitCollectionIfNeeded() {
+    if wrapper.closestViewController is ASDKViewController {
+      // ASDKViewController will handle trait collection changes
+      return
+    }
+    let traitCollection = ASPrimitiveTraitCollectionFromUITraitCollection(traitCollection)
+    let oldTraitCollection = wrapper.primitiveTraitCollection()
+    guard traitCollection.userInterfaceStyle != oldTraitCollection.userInterfaceStyle else {
+      return
+    }
+    ASTraitCollectionPropagateDown(wrapper, traitCollection)
   }
 }
 


### PR DESCRIPTION
`ASTraitCollectionPropagateDown()` is managed by `ASDKViewController`, so for nodes owned by other `UIViewController` subclasses we need to managed them our own.

### After
https://github.com/user-attachments/assets/4a6fa3c9-4deb-42b4-8917-79d9e02978df

